### PR TITLE
[Feat, Fix] 직관일정 상품등록 API로 변경 및 라우터 버그 고침

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,20 +3,27 @@ import GlobalStyles from './style/GlobalStyles';
 import Router from './routes/Router';
 import BottomSheet from './components/CommonBottomSheet';
 import Modal from './components/CommonModal';
+import styled from 'styled-components';
 import { useRecoilState } from 'recoil';
 import { isBottomSheetOpen } from './atom/bottomSheetAtom';
 import { isModalOpen } from './atom/modalAtom';
+
+const ContainerStyle = styled.div`
+  width: 390px;
+  margin: auto;
+  height: 820px;
+`;
 
 function App() {
   const [isBsOpen, setIsBsOpen] = useRecoilState(isBottomSheetOpen);
   const [isModal, setIsModal] = useRecoilState(isModalOpen);
   return (
-    <>
+    <ContainerStyle>
       <GlobalStyles />
       <Router />
       {isBsOpen && <BottomSheet />}
       {isModal && <Modal />}
-    </>
+    </ContainerStyle>
   );
 }
 

--- a/src/api/AddProductAPI.js
+++ b/src/api/AddProductAPI.js
@@ -1,0 +1,52 @@
+import { GET_API, POST_API, DELETE_API } from './CommonAPI';
+import { getHomeImage } from './GameAPI/AddGameAPI';
+
+const addProductAPI = async (token, post, ids, isGame) => {
+  console.log(post);
+  const team_name = isGame ? post.home : post.content.split(',')[3];
+  const content = isGame ? Object.values(post).join(',') : post.content;
+  console.log(team_name, content);
+  const productData = {
+    'product': {
+      'itemName': content,
+      'price': 100,
+      'link': ids.join(','),
+      'itemImage': getHomeImage(team_name),
+    },
+  };
+  const data = await POST_API(token, '/product', productData);
+  console.log(data);
+  return data;
+};
+
+const getProductAPI = async (token, accountname) => {
+  const data = await GET_API(token, `/product/${accountname}`);
+  return data;
+};
+
+const getProductByPostIdAPI = async (token, accountname, ids) => {
+  const plist = await getProductAPI(token, accountname);
+  const data = plist.product.filter((item) => {
+    const idlist = item.link.split(',');
+    if (idlist.includes(ids[0])) {
+      return true;
+    }
+  });
+  console.log(data);
+  return data;
+};
+
+const getProductDetailAPI = async (token, product_id) => {
+  const data = await GET_API(token, `/product/detail/${product_id}`);
+  return data;
+};
+
+const deleteProductAPI = async (token, accountname, ids) => {
+  const plist = await getProductByPostIdAPI(token, accountname, ids);
+  const product_id = plist[0].id;
+  const data = await DELETE_API(token, `/product/${product_id}`);
+  console.log(data);
+  return data;
+};
+
+export { addProductAPI, getProductAPI, getProductDetailAPI, deleteProductAPI };

--- a/src/api/GameAPI/LikeGameAPI.js
+++ b/src/api/GameAPI/LikeGameAPI.js
@@ -1,4 +1,10 @@
 import { GET_API, POST_API_NO_BODY, DELETE_API } from '../CommonAPI';
+import {
+  addProductAPI,
+  getProductAPI,
+  getProductDetailAPI,
+  deleteProductAPI,
+} from '../AddProductAPI';
 import { sortGameByDate, arrToGame } from './AddGameAPI';
 
 // token을 가진 유저가 post_id를 좋아요 눌렀는지 확인합니다.
@@ -10,36 +16,35 @@ const checkLikeAPI = async (token, id) => {
 // post_id의 heartCount를 확인합니다.
 const getLikeCountAPI = async (token, id) => {
   const response = await GET_API(token, `/post/${id}`);
-  console.log(response);
   return response.post.heartCount;
-};
-
-// post_id의 comment를 반환합니다.
-const getCommentAPI = async (token, id) => {
-  const response = await GET_API(token, `/post/${id}`);
-  return response.post.comments;
 };
 
 // token을 가진 유저가 post_ids의 좋아요를 true로 업데이트합니다.
 // ids = arr 형식으로 받습니다.
-const likeGameAPI = async (token, ids) => {
+const likeGameAPI = async (token, ids, isTeam, post, isGame = false) => {
   const returnArr = [];
+  if (isTeam) {
+    const data = await addProductAPI(token, post, ids, isGame);
+  }
   for (const id of ids) {
     const like = await POST_API_NO_BODY(token, `/post/${id}/heart`);
     returnArr.push(like);
   }
+
   return returnArr;
 };
 
 // token을 가진 유저가 post_ids의 좋아요를 false로 업데이트합니다.
 // ids = arr 형식으로 받습니다.
-const unlikeGameAPI = async (token, ids) => {
+const unlikeGameAPI = async (token, ids, isTeam, accountname) => {
   const returnArr = [];
+  if (isTeam) {
+    const data = await deleteProductAPI(token, accountname, ids);
+  }
   for (const id of ids) {
     const unlike = await DELETE_API(token, `/post/${id}/unheart`);
     returnArr.push(unlike);
   }
-  console.log('unlike');
   return returnArr;
 };
 
@@ -76,5 +81,4 @@ export {
   unlikeGameAPI,
   getLikedGameAPI,
   getLikeCountAPI,
-  getCommentAPI,
 };

--- a/src/components/Common/Header/Header.jsx
+++ b/src/components/Common/Header/Header.jsx
@@ -23,7 +23,7 @@ const HeaderStyle = styled.header`
   gap: 10px;
   background: var(--color-navy);
   position: fixed;
-  width: 100%;
+  width: 390px;
   .header-title {
     color: var(--color-lime);
     font-size: 14px;

--- a/src/components/Common/NavBar.jsx
+++ b/src/components/Common/NavBar.jsx
@@ -13,7 +13,7 @@ import { accountname } from '../../atom/loginAtom';
 
 // nav 스타일 컴포넌트
 const NavContainer = styled.nav`
-  width: 100%;
+  width: 390px;
   height: 60px;
   background-color: var(--color-navy);
   position: fixed;

--- a/src/components/List/CardList.jsx
+++ b/src/components/List/CardList.jsx
@@ -10,10 +10,11 @@ const CardListStyle = styled.ul`
 `;
 
 export default function CardList({ games }) {
+  // console.log(games);
   return (
     <CardListStyle>
       {games.map((game) => {
-        return <CardListItem key={game[1][0]} game={game} />;
+        return <CardListItem key={game.id} game={game} />;
       })}
     </CardListStyle>
   );

--- a/src/components/List/CardListItem.jsx
+++ b/src/components/List/CardListItem.jsx
@@ -35,20 +35,18 @@ const CardStyle = styled.li`
 //   };
 
 export default function CardListItem({ game }) {
-  const game_info = game[0];
-  const game_id = game[1];
-  const linkPost = `/post/${game_id[0]}`;
+  const game_info = game.itemName.split(',');
   return (
-    <CardStyle key={game_id[0]}>
-      <Link to={linkPost}>
-        <img className='img-card' src={game_info.image} alt='' />
+    <CardStyle key={game.id}>
+      {/* <Link to={linkPost}> */}
+        <img className='img-card' src={game.itemImage} alt='' />
         <p className='card-title'>
-          {game_info.home} vs. {game_info.away}
+          {game_info[3]} vs. {game_info[4]}
         </p>
         <p className='card-info'>
-          {game_info.date.slice(5)} ({game_info.day}) in {game_info.stadium}
+          {game_info[0].slice(5)} ({game_info[1]}) in {game_info[5]}
         </p>
-      </Link>
+      {/* </Link> */}
     </CardStyle>
   );
 }

--- a/src/components/List/GameListItem.jsx
+++ b/src/components/List/GameListItem.jsx
@@ -7,7 +7,7 @@ import {
   likeGameAPI,
   unlikeGameAPI,
 } from '../../api/GameAPI/LikeGameAPI';
-import { userToken } from '../../atom/loginAtom';
+import { accountname, userToken } from '../../atom/loginAtom';
 import { useRecoilState } from 'recoil';
 
 const ListItemStyle = styled.li`
@@ -45,6 +45,7 @@ export default function GameListItem({ game }) {
   const game_id = game[1];
   const [isLike, setIsLike] = useState(false);
   const [token, setToken] = useRecoilState(userToken);
+  const [accountName, setAccountName] = useRecoilState(accountname);
 
   useEffect(() => {
     const setLike = async () => {
@@ -54,12 +55,11 @@ export default function GameListItem({ game }) {
     setLike();
   }, []);
   const onLikeClick = async () => {
-    console.log(game_id);
     if (isLike) {
-      const unlike = await unlikeGameAPI(token, game_id);
+      const unlike = await unlikeGameAPI(token, game_id, true, accountName);
       setIsLike(unlike[0].post.hearted);
     } else {
-      const like = await likeGameAPI(token, game_id);
+      const like = await likeGameAPI(token, game_id, true, game[0], true);
       setIsLike(like[0].post.hearted);
     }
   };

--- a/src/components/Post/BtnGroup.jsx
+++ b/src/components/Post/BtnGroup.jsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import { likeGameAPI, unlikeGameAPI } from '../../api/GameAPI/LikeGameAPI';
 import { useRecoilState } from 'recoil';
-import { userToken } from '../../atom/loginAtom';
+import { accountname, userToken } from '../../atom/loginAtom';
 
 const BtnWrapperStyle = styled.div`
   text-align: start;
@@ -30,21 +30,21 @@ const BtnWrapperStyle = styled.div`
   }
 `;
 
-export default function BtnGroup({ id, hearted, heartCount, commentCount }) {
+export default function BtnGroup({ id, hearted, heartCount, commentCount, isTeam, post }) {
   const [isLike, setIsLike] = useState(hearted);
   const [likeCount, setLikeCount] = useState(heartCount);
-  const [cmtCount, setCmtCounter] = useState(commentCount);
   const [token, setToken] = useRecoilState(userToken);
+  const [accountName, setAccountName] = useRecoilState(accountname);
 
   const handleLikeClick = async () => {
     if (isLike) {
       console.log('unlike');
-      const unlike = await unlikeGameAPI(token, [id]);
+      const unlike = await unlikeGameAPI(token, [id], isTeam, accountName);
       setIsLike(unlike[0].post.hearted);
       setLikeCount(unlike[0].post.heartCount);
     } else {
       console.log('like');
-      const like = await likeGameAPI(token, [id]);
+      const like = await likeGameAPI(token, [id], isTeam, post);
       setIsLike(like[0].post.hearted);
       setLikeCount(like[0].post.heartCount);
     }
@@ -60,7 +60,7 @@ export default function BtnGroup({ id, hearted, heartCount, commentCount }) {
       <Link to={`/post/${id}`}>
         <button type='button' className='btn-comment'>
           <img src={iconMessage} alt='댓글 달기 버튼' />
-          <span className='num-comment'>{cmtCount}</span>
+          <span className='num-comment'>{commentCount}</span>
         </button>
       </Link>
     </BtnWrapperStyle>

--- a/src/components/Post/Post.jsx
+++ b/src/components/Post/Post.jsx
@@ -89,6 +89,8 @@ export default function Post({ post }) {
             hearted={post.hearted}
             heartCount={post.heartCount}
             commentCount={post.commentCount}
+            isTeam={isTeam}
+            post={post}
           />
           <time className='post-time' dateTime={date}>
             {displayDate}

--- a/src/components/Profile/UserProfile.jsx
+++ b/src/components/Profile/UserProfile.jsx
@@ -6,9 +6,9 @@ import CardList from '../List/CardList';
 import MButton from '../Common/Button/MButton';
 import IconShareBtn from '../../assets/image/icon-share-btn.svg';
 import IconMessageBtn from '../../assets/image/icon-message-btn.svg';
-import { getLikedGameAPI } from '../../api/GameAPI/LikeGameAPI';
 import { useRecoilState } from 'recoil';
-import { userToken } from '../../atom/loginAtom';
+import { userToken, accountname } from '../../atom/loginAtom';
+import { getProductAPI } from '../../api/AddProductAPI';
 
 const LikedGameStyle = styled.section`
   background: white;
@@ -31,18 +31,17 @@ const Container = styled.div`
 function UserProfile({ profile }) {
   const { id } = useParams();
   const navigate = useNavigate();
-  const [likedGame, setLikedGame] = useState([]);
+  const [planGame, setPlanGame] = useState([]);
   const [state, setState] = useState(false);
+  const [token, setToken] = useRecoilState(userToken);
   const handleState = () => {
     setState(!state);
   };
-  const test_token =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjY0ODkyNWZmYjJjYjIwNTY2MzMzY2Y4MyIsImV4cCI6MTY5MTg5NDU0MCwiaWF0IjoxNjg2NzEwNTQwfQ.CMVKaojlNSWLjmtbZ_AY6shkkStQgp1DHP3z87oIPe8';
 
   useEffect(() => {
     const getLikedGameData = async () => {
-      const data = await getLikedGameAPI(test_token);
-      setLikedGame(data);
+      const plan = await getProductAPI(token, id);
+      setPlanGame(plan);
     };
     getLikedGameData();
   }, []);
@@ -70,7 +69,7 @@ function UserProfile({ profile }) {
 
       <LikedGameStyle className='section-game'>
         <h2>직관 일정</h2>
-        <CardList games={likedGame} />
+        {Object.keys(planGame).length > 0 && <CardList games={planGame.product} />}
       </LikedGameStyle>
     </Container>
   );
@@ -78,13 +77,14 @@ function UserProfile({ profile }) {
 
 function MyProfile({ profile }) {
   const navigate = useNavigate();
-  const [likedGame, setLikedGame] = useState([]);
+  const [planGame, setPlanGame] = useState([]);
   const [token, setToken] = useRecoilState(userToken);
+  const [accountName, setAccountName] = useRecoilState(accountname);
 
   useEffect(() => {
     const getLikedGameData = async () => {
-      const data = await getLikedGameAPI(token);
-      setLikedGame(data);
+      const plan = await getProductAPI(token, accountName);
+      setPlanGame(plan);
     };
     getLikedGameData();
   }, []);
@@ -109,7 +109,7 @@ function MyProfile({ profile }) {
 
       <LikedGameStyle className='section-game'>
         <h2>직관 일정</h2>
-        <CardList games={likedGame} />
+        {Object.keys(planGame).length > 0 && <CardList games={planGame.product} />}
       </LikedGameStyle>
     </Container>
   );

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -26,9 +26,8 @@ export default function Profile() {
       const data = await getProfileAPI(token, id);
       setProfile(data.profile);
     };
-
     getProfile();
-  }, []);
+  }, [id]);
   return (
     <>
       <Header text />


### PR DESCRIPTION
## ⚽️ 무엇을 위한 PR인가요?
- [ ] 기능 추가 : 직관일정 상품등록 API로 변경 (좋아요는 다른 유저의 토큰 받는거 불가)
- [ ] 스타일 : 화면 390px로 고정
- [ ] 버그 수정 : profile 라우터 뒤에 parameter 바뀔 때 페이지가 리렌더링되지않는 버그 고침 (useEffect로 parameter가 바뀔때 마다 새로 getProfileAPI함)


## 🏀 기대 결과
-

## ⚾️ 전달사항
-


## 🏐 스크린샷
